### PR TITLE
Add /id endpoint to state and county routes

### DIFF
--- a/api/states.go
+++ b/api/states.go
@@ -11,6 +11,14 @@ import (
 	"time"
 )
 
+func getStateIDs(w http.ResponseWriter, r *http.Request) {
+	err := json.NewEncoder(w).Encode(cmd.StateFips)
+	if err != nil {
+		log.Print(err)
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+}
+
 func getStateGeo(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	stateID := ctx.Value("stateID").(string)
@@ -91,4 +99,5 @@ func stateCTX(next http.Handler) http.Handler {
 func stateAPI(r chi.Router) {
 	r.With(stateCTX).Get("/{stateID}/geo", getStateGeo)
 	r.With(stateCTX).Get("/{stateID}", getStateCases)
+	r.Get("/id", getStateIDs)
 }

--- a/cmd/fips.go
+++ b/cmd/fips.go
@@ -1,7 +1,7 @@
 package cmd
 
-//stateFips is a mapping of state names (uppercase) to FIPS codes
-var stateFips = map[string]int{
+//StateFips is a mapping of state names (uppercase) to FIPS codes
+var StateFips = map[string]int{
 	"ALABAMA":              1,
 	"ALASKA":               2,
 	"ARIZONA":              4,

--- a/cmd/loader.go
+++ b/cmd/loader.go
@@ -153,7 +153,7 @@ func (d *DataLoader) createNewCounty(row []string) (string, error) {
 	} else {
 
 		// Get the state fips code
-		state = fmt.Sprintf("%02d", stateFips[strings.ToUpper(row[1])])
+		state = fmt.Sprintf("%02d", StateFips[strings.ToUpper(row[1])])
 
 		// We need the fips information from the Shapefile database, so query for it
 		err := d.conn.QueryRow(d.ctx, "SELECT t.countyfp FROM tiger as t where (t.name = $1 OR t.namelsad = $1) and t.statefp = $2", row[0], state).Scan(&county)


### PR DESCRIPTION
Added a new /id endpoint to both the county and state routes.

We return a name/id pair which should be useful.