### PR TITLE
Some performance and data loading fixes

### DIFF
--- a/cmd/fips.go
+++ b/cmd/fips.go
@@ -53,4 +53,8 @@ var StateFips = map[string]int{
 	"WEST VIRGINIA":        54,
 	"WISCONSIN":            55,
 	"WYOMING":              56,
+	"AMERICAN SAMOA":       60,
+	"GUAM":                 66,
+	"PUERTO RICO":          72,
+	"US VIRGIN ISLANDS":    78,
 }

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -64,7 +64,7 @@ export async function getCountyCases(
 }
 
 export async function getTopCountyCases(
-    limit: number = 100,
+    limit: number = 10,
     start?: Date,
     end?: Date
 ): Promise<{[key: string]: County[]}> {
@@ -136,7 +136,7 @@ export async function getStateCases(
 }
 
 export async function getTopStateCases(
-    limit: number = 10000,
+    limit: number = 10,
     start?: Date,
     end?: Date
 ): Promise<{[key:string]: State[]}> {

--- a/ui/src/app/AppStore.tsx
+++ b/ui/src/app/AppStore.tsx
@@ -136,25 +136,6 @@ const setCovidData = (state: AppState, { payload }: Action): AppState => {
       }
     });
 
-    // get State - ID map
-    let terrirtories = 0
-    payload.states["99"].forEach(s => {
-      const realID = realStateId[s.State];
-      const realStateData = payload.states[realID];
-      if (realID === undefined) {
-        // TODO: handle Territories
-        terrirtories += s.Confirmed;
-      } else {
-        const index = realStateData.findIndex(
-          realState => realState.Reported.toString() === s.Reported.toString()
-        );
-        realStateData[index].Confirmed += s.Confirmed
-      }
-    });
-    console.log(terrirtories)
-
-    delete payload.states["99"];
-
     return {
       ...state,
       covidTimeSeries: payload,


### PR DESCRIPTION
Add a new index to the cases table, which should help with sorting.

Roll the api limit back down to 10.

Update the handling of unassigned regions to match them to their actual states.