### PR TITLE
Update API methods to support a temporal boundary

### DIFF
--- a/api/counties.go
+++ b/api/counties.go
@@ -56,9 +56,15 @@ func getTopCounties(w http.ResponseWriter, r *http.Request) {
 	log.Println("Returning case data")
 
 	query := "SELECT c.ID, c.County, c.State, s.Update, s.Confirmed, s.NewConfirmed, s.Dead, s.NewDead FROM counties as c " +
-		"LEFT JOIN cases as s " +
-		"ON s.geoid = c.ID " +
-		"ORDER BY c.ID, s.update DESC, s.Confirmed DESC;"
+		"LEFT JOIN cases as s "
+
+	start, ok := r.URL.Query()["start"]
+	if ok && len(start) == 1 {
+		query += "WHERE s.update > %s ", start[0]
+	}
+
+	query += "ON s.geoid = c.ID " +
+			"ORDER BY c.ID, s.update DESC, s.Confirmed DESC;"
 
 	cases, err := queryCountyCasesb(ctx, conn, query)
 	if err != nil {

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -64,18 +64,16 @@ export async function getCountyCases(
 }
 
 export async function getTopCountyCases(
-    limit: number = 10,
     start?: Date,
     end?: Date
 ): Promise<{[key: string]: County[]}> {
   const url = new URL(`/api/county`, window.location.origin);
   if (start) {
-    url.searchParams.append("start", formatDate(start));
+    url.searchParams.append("start", start.toISOString());
   }
   if (end) {
-    url.searchParams.append("end", formatDate(end));
+    url.searchParams.append("end", end.toISOString());
   }
-  url.searchParams.append("limit", limit.toString());
 
   let counties: {[key: string]: County[]} = {};
 
@@ -136,18 +134,16 @@ export async function getStateCases(
 }
 
 export async function getTopStateCases(
-    limit: number = 10,
     start?: Date,
     end?: Date
 ): Promise<{[key:string]: State[]}> {
   const url = new URL(`/api/state`, window.location.origin);
   if (start) {
-    url.searchParams.append("start", formatDate(start));
+    url.searchParams.append("start", start.toISOString());
   }
   if (end) {
-    url.searchParams.append("end", formatDate(end));
+    url.searchParams.append("end", end.toISOString());
   }
-  url.searchParams.append("limit", limit.toString());
 
   let states: {[key: string]: State[]} = {};
 

--- a/ui/src/components/ApiContainer.tsx
+++ b/ui/src/components/ApiContainer.tsx
@@ -4,11 +4,13 @@ import {getTopCountyCases, getTopStateCases} from "../api";
 
 const loadData = async () => {
   const loadStateData = async () => {
-    const chunkedStateData = await getTopStateCases();
+    const date = new Date("2020-03-15 16:23 EDT");
+    const chunkedStateData = await getTopStateCases(date);
     return chunkedStateData;
   };
   const loadCountyData = async () => {
-    const chunkedCountyData = await getTopCountyCases();
+    const date = new Date("2020-03-15 16:23 EDT");
+    const chunkedCountyData = await getTopCountyCases(date);
     return chunkedCountyData;
   };
   return await Promise.all([await loadStateData(), await loadCountyData()]);


### PR DESCRIPTION
We can now limit the amount of data returned from the state and county APIs to only things after a given time point.