### PR TITLE
Prevent app crashing for missing counties

### DIFF
--- a/ui/src/components/Charts/MixedBar.tsx
+++ b/ui/src/components/Charts/MixedBar.tsx
@@ -26,11 +26,16 @@ export const MixedBar = (props: Props) => {
   const data = dates.map(date => {
     let total = 0;
     if (props.county) {
-      total = props.timeSeries.counties[props.county]
-        .filter(c => monthDay(c.Reported) === date)
-        .reduce((acc, el) => {
-          return acc + el[props.stat === "confirmed" ? "Confirmed" : "Dead"];
-        }, 0);
+      const county = props.timeSeries.counties[props.county];
+      total = county
+        ? county
+            .filter(c => monthDay(c.Reported) === date)
+            .reduce((acc, el) => {
+              return (
+                acc + el[props.stat === "confirmed" ? "Confirmed" : "Dead"]
+              );
+            }, 0)
+        : 0;
       maxCasesByDate[date] = (maxCasesByDate[date] || 0) + total;
     } else if (props.state) {
       // We just need the first value in order to match the counties

--- a/ui/src/components/USATotals.tsx
+++ b/ui/src/components/USATotals.tsx
@@ -20,6 +20,9 @@ const USATotal: React.FunctionComponent<Props> = props => {
   const total = grandTotals[dates[0]]?.Confirmed;
 
   const renderChange = (current: number, previous: number) => {
+    if (current === undefined || previous === undefined) {
+      return "N/A";
+    }
     const change = current - previous;
     return `${change >= 0 ? "+" : ""}${change} (${percentChange(
       current,


### PR DESCRIPTION
- If a county with no data is selected the app crashes. This prevents that from happening
- Also fixes NaN display in totals