### PR TITLE
Migrate to zerologger

### DIFF
--- a/api/states.go
+++ b/api/states.go
@@ -4,18 +4,19 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"time"
+
 	"github.com/go-chi/chi"
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/nickrobison-usds/demand-modeling/cmd"
-	"log"
-	"net/http"
-	"time"
+	"github.com/rs/zerolog/log"
 )
 
 func getStateIDs(w http.ResponseWriter, r *http.Request) {
 	err := json.NewEncoder(w).Encode(cmd.StateFips)
 	if err != nil {
-		log.Print(err)
+		log.Error().Err(err).Msg("Cannot encode state FIPs")
 		w.WriteHeader(http.StatusInternalServerError)
 	}
 }
@@ -24,7 +25,7 @@ func getStates(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	conn, err := ctx.Value("db").(*pgxpool.Pool).Acquire(ctx)
 	if err != nil {
-		log.Print(err)
+		log.Error().Err(err).Msg("Cannot get DB from context")
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
@@ -38,7 +39,7 @@ func getStates(w http.ResponseWriter, r *http.Request) {
 	if ok && len(start) == 1 {
 		startTime, err := time.Parse(time.RFC3339, start[0])
 		if err != nil {
-			log.Print(err)
+			log.Error().Err(err).Msg("Cannot decode start time parameter")
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
@@ -49,14 +50,14 @@ func getStates(w http.ResponseWriter, r *http.Request) {
 
 	cases, err := queryStateCases(ctx, conn, query)
 	if err != nil {
-		log.Print(err)
+		log.Error().Err(err).Msg("Cannot query for state cases")
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
 	err = json.NewEncoder(w).Encode(cases)
 	if err != nil {
-		log.Print(err)
+		log.Error().Err(err).Msg("Cannot encode to json")
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
@@ -65,18 +66,29 @@ func getStates(w http.ResponseWriter, r *http.Request) {
 func getStateGeo(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	stateID := ctx.Value("stateID").(string)
-	conn := ctx.Value("db").(*pgxpool.Pool)
+	conn, err := ctx.Value("db").(*pgxpool.Pool).Acquire(ctx)
+	if err != nil {
+		log.Error().Err(err).Msg("Get DB from context")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	defer conn.Release()
 
 	geo := &json.RawMessage{}
-	err := conn.QueryRow(ctx, "SELECT ST_AsGeoJSON(geom) FROM states "+
+	err = conn.QueryRow(ctx, "SELECT ST_AsGeoJSON(geom) FROM states "+
 		"WHERE statefp = $1;", stateID).Scan(geo)
 	if err != nil {
-		log.Print(err)
+		log.Error().Err(err).Msg("Cannot execute state geo query")
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
 	err = json.NewEncoder(w).Encode(geo)
+	if err != nil {
+		log.Error().Err(err).Msg("Cannot encode to json")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
 }
 
 func getStateCases(w http.ResponseWriter, r *http.Request) {
@@ -84,13 +96,13 @@ func getStateCases(w http.ResponseWriter, r *http.Request) {
 	stateID := ctx.Value("stateID").(string)
 	conn, err := ctx.Value("db").(*pgxpool.Pool).Acquire(ctx)
 	if err != nil {
-		log.Print(err)
+		log.Error().Err(err).Msg("Cannot get DB from context")
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 	defer conn.Release()
 
-	log.Println("Returning case data for state: " + stateID)
+	log.Debug().Msgf("Returning case data for state: %s\n", stateID)
 
 	query := "SELECT c.statefp, c.state, a.update, SUM(a.confirmed) as confirmed, SUM(a.newconfirmed), SUM(a.dead), SUM(a.newdead) from counties as c " +
 		"LEFT JOIN cases as a ON c.id = a.geoid " +
@@ -100,14 +112,14 @@ func getStateCases(w http.ResponseWriter, r *http.Request) {
 
 	cases, err := queryStateCases(ctx, conn, query, stateID)
 	if err != nil {
-		log.Print(err)
+		log.Error().Err(err).Msg("Cannot query state cases")
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
 	err = json.NewEncoder(w).Encode(cases)
 	if err != nil {
-		log.Print(err)
+		log.Error().Err(err).Msg("Cannot encode to json")
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
@@ -153,7 +165,7 @@ func queryStateCases(ctx context.Context, conn *pgxpool.Conn, sql string, args .
 func stateCTX(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		countyID := chi.URLParam(r, "stateID")
-		log.Println("ID from param: " + countyID)
+		log.Debug().Msgf("ID from param: %s\n", countyID)
 		ctx := context.WithValue(r.Context(), "stateID", countyID)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})

--- a/cmd/usafacts.go
+++ b/cmd/usafacts.go
@@ -5,13 +5,14 @@ import (
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
-	"github.com/urfave/cli/v2"
 	"io"
-	"log"
 	"net/http"
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/rs/zerolog/log"
+	"github.com/urfave/cli/v2"
 )
 
 const startDate string = "Jan 22 00:00:00"
@@ -62,7 +63,7 @@ func USALoaderCMD() *cli.Command {
 				return err
 			}
 
-			log.Println("Wrote CSV: " + filename)
+			log.Info().Msgf("Wrote CSV: " + filename)
 			return nil
 		},
 	}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,8 @@ require (
 	github.com/go-chi/cors v1.0.1
 	github.com/golang-migrate/migrate/v4 v4.10.0
 	github.com/jackc/pgx/v4 v4.5.0
+	github.com/rs/zerolog v1.15.0
 	github.com/stretchr/testify v1.5.1
+	github.com/rs/zerolog v1.15.0
 	github.com/urfave/cli/v2 v2.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -259,6 +259,7 @@ github.com/remyoudompheng/bigfft v0.0.0-20190728182440-6a916e37a237/go.mod h1:qq
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rs/zerolog v1.13.0/go.mod h1:YbFCdg8HfsridGWAh22vktObvhZbQsZXe4/zB0OKkWU=
+github.com/rs/zerolog v1.15.0 h1:uPRuwkWF4J6fGsJ2R0Gn2jB1EQiav9k3S6CSdygQJXY=
 github.com/rs/zerolog v1.15.0/go.mod h1:xYTKnLHcpfU2225ny5qZjxnj9NvkumZYjJHlAThCjNc=
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/main.go
+++ b/main.go
@@ -3,6 +3,11 @@ package main
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
 	"github.com/go-chi/chi"
 	"github.com/go-chi/chi/middleware"
 	"github.com/go-chi/cors"
@@ -12,16 +17,15 @@ import (
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/nickrobison-usds/demand-modeling/api"
 	"github.com/nickrobison-usds/demand-modeling/cmd"
-	"log"
-	"net/http"
-	"os"
-	"path/filepath"
-	"strings"
-
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 	"github.com/urfave/cli/v2"
 )
 
 func main() {
+
+	// Initialize logger
+	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
 
 	app := &cli.App{
 		Name: "Fearless Dreamer",
@@ -33,14 +37,14 @@ func main() {
 
 	err := app.Run(os.Args)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal().Err(err).Send()
 	}
 }
 
 func runServer(c *cli.Context) error {
 	workDir, err := os.Getwd()
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal().Err(err).Send()
 	}
 	filesDir := filepath.Join(workDir, "ui/build")
 
@@ -48,25 +52,25 @@ func runServer(c *cli.Context) error {
 	// Do the migration
 	err = migrateDatabase(url, workDir)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal().Err(err).Send()
 	}
 
 	// Load it up
 	ctx := context.Background()
 	pool, err := pgxpool.Connect(ctx, url)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal().Err(err).Send()
 	}
 	defer pool.Close()
 	loader, err := cmd.NewLoader(ctx, url, filepath.Join(workDir, "data"))
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal().Err(err).Send()
 	}
 	defer loader.Close()
 
 	err = loader.Load()
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal().Err(err).Send()
 	}
 
 	return serve(pool, filesDir)


### PR DESCRIPTION
Move logging calls to zerologger, which gives us much more control over the output level logging.