### PR TITLE
Refactor data backend

### DIFF
--- a/api/backend.go
+++ b/api/backend.go
@@ -1,0 +1,19 @@
+package api
+
+import (
+	"context"
+	"time"
+
+	"github.com/nickrobison-usds/demand-modeling/cmd"
+)
+
+// DataBackend defines the interface for retrieving required information from an abstract data source
+type DataBackend interface {
+	// County APIs
+	GetCountyIDs(ctx context.Context) (map[string]string, error)
+	GetTopCounties(ctx context.Context, start *time.Time) ([]cmd.CountyCases, error)
+	GetCountyCases(ctx context.Context, countyID string) ([]cmd.CountyCases, error)
+	// State APIs
+	GetTopStates(ctx context.Context, start *time.Time) ([]cmd.StateCases, error)
+	GetStateCases(ctx context.Context, stateID string) ([]cmd.StateCases, error)
+}

--- a/api/backend.go
+++ b/api/backend.go
@@ -7,6 +7,11 @@ import (
 	"github.com/nickrobison-usds/demand-modeling/cmd"
 )
 
+type keyInterface interface{}
+
+// BackendKey type for accessing backend from context
+var BackendKey keyInterface = 0
+
 // DataBackend defines the interface for retrieving required information from an abstract data source
 type DataBackend interface {
 	// County APIs

--- a/api/counties.go
+++ b/api/counties.go
@@ -7,41 +7,13 @@ import (
 	"time"
 
 	"github.com/go-chi/chi"
-	"github.com/jackc/pgx/v4/pgxpool"
-	"github.com/nickrobison-usds/demand-modeling/cmd"
 	"github.com/rs/zerolog/log"
 )
 
 func getCountIDs(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	backend := ctx.Value("db").(DataBackend)
-	// conn, err := ctx.Value("db").(*pgxpool.Pool).Acquire(ctx)
-	// if err != nil {
-	// 	log.Error().Err(err).Msg("Get DB from context")
-	// 	w.WriteHeader(http.StatusInternalServerError)
-	// 	return
-	// }
-	// defer conn.Release()
+	backend := ctx.Value(BackendKey).(DataBackend)
 
-	// rows, err := conn.Query(ctx, "SELECT county || ', ' || state as name, id from counties")
-	// if err != nil {
-	// 	log.Error().Err(err).Msg("Cannot execute County ID query")
-	// 	w.WriteHeader(http.StatusInternalServerError)
-	// 	return
-	// }
-
-	// ids := make(map[string]string, 0)
-	// for rows.Next() {
-	// 	var name string
-	// 	var id string
-	// 	err = rows.Scan(&name, &id)
-	// 	if err != nil {
-	// 		log.Error().Err(err).Msg("Cannot read row from database")
-	// 		w.WriteHeader(http.StatusInternalServerError)
-	// 		return
-	// 	}
-	// 	ids[name] = id
-	// }
 	ids, err := backend.GetCountyIDs(ctx)
 	if err != nil {
 		log.Error().Err(err).Msg("Cannot write to json")
@@ -58,19 +30,7 @@ func getCountIDs(w http.ResponseWriter, r *http.Request) {
 func getTopCounties(w http.ResponseWriter, r *http.Request) {
 	log.Debug().Msg("Loading top counties")
 	ctx := r.Context()
-	backend := ctx.Value("db").(DataBackend)
-	// if err != nil {
-	// 	log.Error().Err(err).Msg("Get DB from context")
-	// 	w.WriteHeader(http.StatusInternalServerError)
-	// 	return
-	// }
-	// defer conn.Release()
-
-	// log.Debug().Msg("Returning case data")
-
-	// query := "SELECT c.ID, c.County, c.State, s.Update, s.Confirmed, s.NewConfirmed, s.Dead, s.NewDead FROM counties as c " +
-	// 	"LEFT JOIN cases as s " +
-	// 	"ON s.geoid = c.ID "
+	backend := ctx.Value(BackendKey).(DataBackend)
 
 	var startTime *time.Time = nil
 	start, ok := r.URL.Query()["start"]
@@ -83,17 +43,6 @@ func getTopCounties(w http.ResponseWriter, r *http.Request) {
 		}
 		startTime = &t
 	}
-	// 	query = fmt.Sprintf("%s WHERE s.update > '%s' ", query, startTime.Format(time.RFC3339))
-	// }
-
-	// query = query + "ORDER BY c.ID, s.update DESC, s.Confirmed DESC;"
-
-	// cases, err := queryCountyCases(ctx, conn, query)
-	// if err != nil {
-	// 	log.Error().Err(err).Msg("Cannot execute county queries")
-	// 	w.WriteHeader(http.StatusInternalServerError)
-	// 	return
-	// }
 
 	cases, err := backend.GetTopCounties(ctx, startTime)
 	if err != nil {
@@ -110,61 +59,10 @@ func getTopCounties(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func getCountyGeo(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-	countyID := ctx.Value("countyID").(string)
-	conn, err := ctx.Value("db").(*pgxpool.Pool).Acquire(ctx)
-	if err != nil {
-		log.Error().Err(err).Msg("Get DB from context")
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-	defer conn.Release()
-
-	geo := &json.RawMessage{}
-	err = conn.QueryRow(ctx, "SELECT ST_AsGeoJSON(t.geom) as geom FROM counties as c "+
-		"LEFT JOIN tiger as t "+
-		"ON c.ID = t.geoid "+
-		"WHERE c.id = $1;", countyID).Scan(geo)
-	if err != nil {
-		log.Error().Err(err).Msg("Cannot execute geo query")
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
-	err = json.NewEncoder(w).Encode(geo)
-	if err != nil {
-		log.Error().Err(err).Msg("Cannot write to json")
-		w.WriteHeader(http.StatusInternalServerError)
-	}
-}
-
 func getCountyCases(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	countyID := ctx.Value("countyID").(string)
-	backend := ctx.Value("db").(DataBackend)
-	// if err != nil {
-	// 	log.Error().Err(err).Msg("Get DB from context")
-	// 	w.WriteHeader(http.StatusInternalServerError)
-	// 	return
-	// }
-	// defer conn.Release()
-
-	// // log.Debug().Msgf("Returning case data for county: %s\n" + countyID)
-
-	// // query := "SELECT c.ID, c.County, c.State, s.Update, s.Confirmed, s.NewConfirmed, s.Dead, s.NewDead, ST_AsGeoJSON(t.geom) as geom FROM counties as c " +
-	// // 	"LEFT JOIN tiger as t " +
-	// // 	"ON c.ID = t.geoid " +
-	// // 	"LEFT JOIN cases as s " +
-	// // 	"ON s.geoid = c.ID WHERE c.id = $1 " +
-	// // 	"ORDER BY update DESC;"
-
-	// // cases, err := queryCountyCases(ctx, conn, query, countyID)
-	// // if err != nil {
-	// // 	log.Error().Err(err).Msg("Cannot execute county cases query")
-	// // 	w.WriteHeader(http.StatusInternalServerError)
-	// // 	return
-	// // }
+	backend := ctx.Value(BackendKey).(DataBackend)
 
 	cases, err := backend.GetCountyCases(ctx, countyID)
 	if err != nil {
@@ -182,49 +80,6 @@ func getCountyCases(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func queryCountyCases(ctx context.Context, conn *pgxpool.Conn, sql string, args ...interface{}) ([]cmd.CountyCases, error) {
-	cases := make([]cmd.CountyCases, 0)
-
-	rows, err := conn.Query(ctx, sql, args...)
-	if err != nil {
-		return cases, err
-	}
-
-	log.Debug().Msg("Case counties are loaded")
-	for rows.Next() {
-		var id string
-		var county string
-		var state string
-		var updated time.Time
-		var confirmed int
-		var newConfirmed int
-		var dead int
-		var newDead int
-		geo := &json.RawMessage{}
-		err := rows.Scan(&id, &county, &state, &updated, &confirmed, &newConfirmed, &dead, &newDead, geo)
-		if err != nil {
-			return cases, err
-		}
-
-		caseCount := &cmd.CaseCount{
-			Confirmed:    confirmed,
-			NewConfirmed: newConfirmed,
-			Dead:         dead,
-			NewDead:      newDead,
-			Reported:     updated,
-		}
-
-		cases = append(cases, cmd.CountyCases{
-			ID:        id,
-			County:    county,
-			State:     state,
-			CaseCount: caseCount,
-		})
-	}
-
-	return cases, nil
-}
-
 func countyCTX(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		countyID := chi.URLParam(r, "countyID")
@@ -237,7 +92,6 @@ func countyCTX(next http.Handler) http.Handler {
 func countyAPI(r chi.Router) {
 	// For some reason, the URL param context doesn't work unless you use the .with directly on the methods
 	r.With(countyCTX).Get("/{countyID}", getCountyCases)
-	r.With(countyCTX).Get("/{countyID}/geo", getCountyGeo)
 	r.Get("/id", getCountIDs)
 	r.Get("/", getTopCounties)
 }

--- a/api/router.go
+++ b/api/router.go
@@ -23,7 +23,7 @@ func subHandler() http.HandlerFunc {
 func BackendContext(backend DataBackend) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			ctx := context.WithValue(r.Context(), "db", backend)
+			ctx := context.WithValue(r.Context(), BackendKey, backend)
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}

--- a/api/router.go
+++ b/api/router.go
@@ -2,9 +2,9 @@ package api
 
 import (
 	"context"
-	"github.com/go-chi/chi"
-	"github.com/jackc/pgx/v4/pgxpool"
 	"net/http"
+
+	"github.com/go-chi/chi"
 )
 
 func rootHandler() http.HandlerFunc {
@@ -19,15 +19,17 @@ func subHandler() http.HandlerFunc {
 	}
 }
 
-func DBContext(conn *pgxpool.Pool) func(next http.Handler) http.Handler {
+// BackendContext injects the DataBackend into the http handler
+func BackendContext(backend DataBackend) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			ctx := context.WithValue(r.Context(), "db", conn)
+			ctx := context.WithValue(r.Context(), "db", backend)
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
 }
 
+// MakeRouter creates and returns the API routes
 func MakeRouter(r chi.Router) {
 	r.Get("/", rootHandler())
 	r.Get("/sub", subHandler())

--- a/api/states.go
+++ b/api/states.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/go-chi/chi"
-	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/nickrobison-usds/demand-modeling/cmd"
 	"github.com/rs/zerolog/log"
 )
@@ -22,11 +21,7 @@ func getStateIDs(w http.ResponseWriter, r *http.Request) {
 
 func getStates(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	backend := ctx.Value("db").(DataBackend)
-
-	// query := "SELECT c.statefp, c.State, s.Update, SUM(s.Confirmed) as confirmed, SUM(s.NewConfirmed), SUM(s.Dead), SUM(s.NewDead) FROM counties as c " +
-	// 	"LEFT JOIN cases as s " +
-	// 	"ON s.geoid = c.ID "
+	backend := ctx.Value(BackendKey).(DataBackend)
 
 	var t *time.Time = nil
 	start, ok := r.URL.Query()["start"]
@@ -39,17 +34,6 @@ func getStates(w http.ResponseWriter, r *http.Request) {
 		}
 		t = &startTime
 	}
-	// 	query = fmt.Sprintf("%s WHERE s.update > '%s' ", query, startTime.Format(time.RFC3339))
-	// }
-	// query = query + "GROUP BY c.statefp, c.state, s.update " +
-	// 	"ORDER BY c.state, s.update;"
-
-	// cases, err := queryStateCases(ctx, conn, query)
-	// if err != nil {
-	// 	log.Error().Err(err).Msg("Cannot query for state cases")
-	// 	w.WriteHeader(http.StatusInternalServerError)
-	// 	return
-	// }
 	cases, err := backend.GetTopStates(ctx, t)
 	if err != nil {
 		log.Error().Err(err).Msg("Cannot query for state cases")
@@ -65,60 +49,10 @@ func getStates(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func getStateGeo(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-	stateID := ctx.Value("stateID").(string)
-	conn, err := ctx.Value("db").(*pgxpool.Pool).Acquire(ctx)
-	if err != nil {
-		log.Error().Err(err).Msg("Get DB from context")
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-	defer conn.Release()
-
-	geo := &json.RawMessage{}
-	err = conn.QueryRow(ctx, "SELECT ST_AsGeoJSON(geom) FROM states "+
-		"WHERE statefp = $1;", stateID).Scan(geo)
-	if err != nil {
-		log.Error().Err(err).Msg("Cannot execute state geo query")
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
-	err = json.NewEncoder(w).Encode(geo)
-	if err != nil {
-		log.Error().Err(err).Msg("Cannot encode to json")
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-}
-
 func getStateCases(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	stateID := ctx.Value("stateID").(string)
-	backend := ctx.Value("db").(DataBackend)
-	// conn, err := ctx.Value("db").(*pgxpool.Pool).Acquire(ctx)
-	// if err != nil {
-	// 	log.Error().Err(err).Msg("Cannot get DB from context")
-	// 	w.WriteHeader(http.StatusInternalServerError)
-	// 	return
-	// }
-	// defer conn.Release()
-
-	// log.Debug().Msgf("Returning case data for state: %s\n", stateID)
-
-	// query := "SELECT c.statefp, c.state, a.update, SUM(a.confirmed) as confirmed, SUM(a.newconfirmed), SUM(a.dead), SUM(a.newdead) from counties as c " +
-	// 	"LEFT JOIN cases as a ON c.id = a.geoid " +
-	// 	"WHERE c.statefp = $1 " +
-	// 	"GROUP BY c.statefp, c.state, a.update " +
-	// 	"ORDER BY a.update DESC, confirmed DESC"
-
-	// cases, err := queryStateCases(ctx, conn, query, stateID)
-	// if err != nil {
-	// 	log.Error().Err(err).Msg("Cannot query state cases")
-	// 	w.WriteHeader(http.StatusInternalServerError)
-	// 	return
-	// }
+	backend := ctx.Value(BackendKey).(DataBackend)
 	cases, err := backend.GetStateCases(ctx, stateID)
 	if err != nil {
 		log.Error().Err(err).Msg("Cannot query state cases")
@@ -134,43 +68,6 @@ func getStateCases(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// func queryStateCases(ctx context.Context, conn *pgxpool.Conn, sql string, args ...interface{}) ([]cmd.StateCases, error) {
-// 	cases := make([]cmd.StateCases, 0)
-
-// 	rows, err := conn.Query(ctx, sql, args...)
-// 	if err != nil {
-// 		return cases, err
-// 	}
-
-// 	for rows.Next() {
-// 		var id string
-// 		var state string
-// 		var confirmed int
-// 		var newConfirmed int
-// 		var dead int
-// 		var newDead int
-// 		var reported time.Time
-// 		err := rows.Scan(&id, &state, &reported, &confirmed, &newConfirmed, &dead, &newDead)
-// 		if err != nil {
-// 			return cases, err
-// 		}
-// 		caseCount := &cmd.CaseCount{
-// 			Confirmed:    confirmed,
-// 			NewConfirmed: newConfirmed,
-// 			Dead:         dead,
-// 			NewDead:      newDead,
-// 			Reported:     reported,
-// 		}
-
-// 		cases = append(cases, cmd.StateCases{
-// 			ID:        id,
-// 			State:     state,
-// 			CaseCount: caseCount,
-// 		})
-// 	}
-// 	return cases, nil
-// }
-
 func stateCTX(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		countyID := chi.URLParam(r, "stateID")
@@ -181,7 +78,6 @@ func stateCTX(next http.Handler) http.Handler {
 }
 
 func stateAPI(r chi.Router) {
-	r.With(stateCTX).Get("/{stateID}/geo", getStateGeo)
 	r.With(stateCTX).Get("/{stateID}", getStateCases)
 	r.Get("/id", getStateIDs)
 	r.Get("/", getStates)

--- a/dbbackend/backend.go
+++ b/dbbackend/backend.go
@@ -2,7 +2,6 @@ package dbbackend
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -181,8 +180,7 @@ func queryCountyCases(ctx context.Context, conn *pgxpool.Conn, sql string, args 
 		var newConfirmed int
 		var dead int
 		var newDead int
-		geo := &json.RawMessage{}
-		err := rows.Scan(&id, &county, &state, &updated, &confirmed, &newConfirmed, &dead, &newDead, geo)
+		err := rows.Scan(&id, &county, &state, &updated, &confirmed, &newConfirmed, &dead, &newDead)
 		if err != nil {
 			return cases, err
 		}

--- a/dbbackend/backend.go
+++ b/dbbackend/backend.go
@@ -1,0 +1,244 @@
+package dbbackend
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/nickrobison-usds/demand-modeling/cmd"
+	"github.com/rs/zerolog/log"
+)
+
+// DBBackend api.DataBackend for communicating with Postgres db
+type DBBackend struct {
+	pool *pgxpool.Pool
+}
+
+// NewBackend creates a new DBBackend
+func NewBackend(ctx context.Context, url string) (*DBBackend, error) {
+	// Create the pool
+	pool, err := pgxpool.Connect(ctx, url)
+	if err != nil {
+		return nil, err
+	}
+
+	return &DBBackend{
+		pool: pool,
+	}, nil
+}
+
+func (d *DBBackend) GetCountyIDs(ctx context.Context) (map[string]string, error) {
+	ids := make(map[string]string, 0)
+	conn, err := d.pool.Acquire(ctx)
+	if err != nil {
+		return ids, err
+	}
+	defer conn.Release()
+
+	rows, err := conn.Query(ctx, "SELECT county || ', ' || state as name, id from counties")
+	if err != nil {
+		log.Error().Err(err).Msg("Cannot execute County ID query")
+		return ids, err
+	}
+	for rows.Next() {
+		var name string
+		var id string
+		err = rows.Scan(&name, &id)
+		if err != nil {
+			log.Error().Err(err).Msg("Cannot read row from database")
+			return ids, err
+		}
+		ids[name] = id
+	}
+
+	return ids, nil
+}
+
+func (d *DBBackend) GetTopCounties(ctx context.Context, start *time.Time) ([]cmd.CountyCases, error) {
+	log.Debug().Msg("Loading top counties")
+	var cases []cmd.CountyCases = []cmd.CountyCases{}
+	conn, err := d.pool.Acquire(ctx)
+	if err != nil {
+		return cases, err
+	}
+	defer conn.Release()
+
+	log.Debug().Msg("Returning case data")
+
+	query := "SELECT c.ID, c.County, c.State, s.Update, s.Confirmed, s.NewConfirmed, s.Dead, s.NewDead FROM counties as c " +
+		"LEFT JOIN cases as s " +
+		"ON s.geoid = c.ID "
+
+	if start != nil {
+		query = fmt.Sprintf("%s WHERE s.update > '%s' ", query, start.Format(time.RFC3339))
+	}
+
+	query = query + "ORDER BY c.ID, s.update DESC, s.Confirmed DESC;"
+
+	cases, err = queryCountyCases(ctx, conn, query)
+	if err != nil {
+		return cases, err
+	}
+
+	return cases, nil
+}
+
+func (d *DBBackend) GetCountyCases(ctx context.Context, countyID string) ([]cmd.CountyCases, error) {
+	var cases []cmd.CountyCases = []cmd.CountyCases{}
+	conn, err := d.pool.Acquire(ctx)
+	if err != nil {
+		return cases, err
+	}
+	defer conn.Release()
+
+	log.Debug().Msgf("Returning case data for county: %s\n" + countyID)
+
+	query := "SELECT c.ID, c.County, c.State, s.Update, s.Confirmed, s.NewConfirmed, s.Dead, s.NewDead, ST_AsGeoJSON(t.geom) as geom FROM counties as c " +
+		"LEFT JOIN tiger as t " +
+		"ON c.ID = t.geoid " +
+		"LEFT JOIN cases as s " +
+		"ON s.geoid = c.ID WHERE c.id = $1 " +
+		"ORDER BY update DESC;"
+
+	cases, err = queryCountyCases(ctx, conn, query, countyID)
+	if err != nil {
+		return cases, err
+	}
+	return cases, nil
+}
+
+func (d *DBBackend) GetTopStates(ctx context.Context, start *time.Time) ([]cmd.StateCases, error) {
+	var cases []cmd.StateCases = []cmd.StateCases{}
+	conn, err := d.pool.Acquire(ctx)
+	if err != nil {
+		return cases, err
+	}
+	defer conn.Release()
+
+	query := "SELECT c.statefp, c.State, s.Update, SUM(s.Confirmed) as confirmed, SUM(s.NewConfirmed), SUM(s.Dead), SUM(s.NewDead) FROM counties as c " +
+		"LEFT JOIN cases as s " +
+		"ON s.geoid = c.ID "
+
+	if start != nil {
+		query = fmt.Sprintf("%s WHERE s.update > '%s' ", query, start.Format(time.RFC3339))
+	}
+	query = query + "GROUP BY c.statefp, c.state, s.update " +
+		"ORDER BY c.state, s.update;"
+
+	cases, err = queryStateCases(ctx, conn, query)
+	if err != nil {
+		return cases, err
+	}
+
+	return cases, nil
+}
+
+func (d *DBBackend) GetStateCases(ctx context.Context, stateID string) ([]cmd.StateCases, error) {
+	log.Debug().Msgf("Returning case data for state: %s", stateID)
+	var cases []cmd.StateCases = []cmd.StateCases{}
+	conn, err := d.pool.Acquire(ctx)
+	if err != nil {
+		return cases, err
+	}
+	defer conn.Release()
+
+	query := "SELECT c.statefp, c.state, a.update, SUM(a.confirmed) as confirmed, SUM(a.newconfirmed), SUM(a.dead), SUM(a.newdead) from counties as c " +
+		"LEFT JOIN cases as a ON c.id = a.geoid " +
+		"WHERE c.statefp = $1 " +
+		"GROUP BY c.statefp, c.state, a.update " +
+		"ORDER BY a.update DESC, confirmed DESC"
+
+	cases, err = queryStateCases(ctx, conn, query, stateID)
+	if err != nil {
+		return cases, err
+	}
+
+	return cases, nil
+}
+
+// Shutdown closes all connections and releases all resources
+func (d *DBBackend) Shutdown() {
+	d.pool.Close()
+}
+
+func queryCountyCases(ctx context.Context, conn *pgxpool.Conn, sql string, args ...interface{}) ([]cmd.CountyCases, error) {
+	cases := make([]cmd.CountyCases, 0)
+
+	rows, err := conn.Query(ctx, sql, args...)
+	if err != nil {
+		return cases, err
+	}
+
+	log.Debug().Msg("Case counties are loaded")
+	for rows.Next() {
+		var id string
+		var county string
+		var state string
+		var updated time.Time
+		var confirmed int
+		var newConfirmed int
+		var dead int
+		var newDead int
+		geo := &json.RawMessage{}
+		err := rows.Scan(&id, &county, &state, &updated, &confirmed, &newConfirmed, &dead, &newDead, geo)
+		if err != nil {
+			return cases, err
+		}
+
+		caseCount := &cmd.CaseCount{
+			Confirmed:    confirmed,
+			NewConfirmed: newConfirmed,
+			Dead:         dead,
+			NewDead:      newDead,
+			Reported:     updated,
+		}
+
+		cases = append(cases, cmd.CountyCases{
+			ID:        id,
+			County:    county,
+			State:     state,
+			CaseCount: caseCount,
+		})
+	}
+
+	return cases, nil
+}
+
+func queryStateCases(ctx context.Context, conn *pgxpool.Conn, sql string, args ...interface{}) ([]cmd.StateCases, error) {
+	cases := make([]cmd.StateCases, 0)
+
+	rows, err := conn.Query(ctx, sql, args...)
+	if err != nil {
+		return cases, err
+	}
+
+	for rows.Next() {
+		var id string
+		var state string
+		var confirmed int
+		var newConfirmed int
+		var dead int
+		var newDead int
+		var reported time.Time
+		err := rows.Scan(&id, &state, &reported, &confirmed, &newConfirmed, &dead, &newDead)
+		if err != nil {
+			return cases, err
+		}
+		caseCount := &cmd.CaseCount{
+			Confirmed:    confirmed,
+			NewConfirmed: newConfirmed,
+			Dead:         dead,
+			NewDead:      newDead,
+			Reported:     reported,
+		}
+
+		cases = append(cases, cmd.StateCases{
+			ID:        id,
+			State:     state,
+			CaseCount: caseCount,
+		})
+	}
+	return cases, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,5 @@ require (
 	github.com/jackc/pgx/v4 v4.5.0
 	github.com/rs/zerolog v1.15.0
 	github.com/stretchr/testify v1.5.1
-	github.com/rs/zerolog v1.15.0
 	github.com/urfave/cli/v2 v2.2.0
 )


### PR DESCRIPTION
Refactor the backend to no longer directly rely on the databse. Instead, it now takes an injected `DataBackend` interface, which abstract over the underlying datastore.

This not only cleans up the API handlers, but also makes it easier to port the application to another data source (such as Palantir).