### PR TITLE
Revert NY population merge

### DIFF
--- a/ui/src/components/Charts/population.tsx
+++ b/ui/src/components/Charts/population.tsx
@@ -3194,13 +3194,3 @@ export const population: { [fipsKey: string]: number } = {
   "56043": 8328,
   "56045": 7234
 };
-
-// Consolidate NY Counties
-const nyFips = "36061";
-const otherNyFips = ["36085", "36047", "36081", "36005"];
-otherNyFips.forEach(county => {
-  if (population[county]) {
-    population[nyFips] += population[county];
-    delete population[county];
-  }
-});


### PR DESCRIPTION
The New York FIPS population already includes the 5 boroughs, so we don't need to merge their populations, like we do with their boundaries.