### PR TITLE
cloud.gov Deploy

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,0 +1,8 @@
+.idea/
+data/tl_*
+*.iml
+node_modules
+package-lock.json
+ui/node_modules
+.env.local
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 1. Create a cloud.gov application
     1. Update `manifest.yml` with the service name identified in step 1
     1. Change the name of the applications if needed, verifying the URLs are correct
-    1. Run `cf push`
+    1. Run `yarn run deploy`
     1. Done!
 
 ## Bootstrapping Heroku

--- a/README.md
+++ b/README.md
@@ -27,6 +27,18 @@
   docker-compose up --build api
   ```
 
+## Bootstrapping Cloud.gov
+
+1. Create a cloud.gov database service
+    1. Use the relational database template
+    1. Select a `psql`-based instance
+    1. Skip binding the service to an instance
+1. Create a cloud.gov application
+    1. Update `manifest.yml` with the service name identified in step 1
+    1. Change the name of the applications if needed, verifying the URLs are correct
+    1. Run `cf push`
+    1. Done!
+
 ## Bootstrapping Heroku
 
 1. Create a Postgres service and link it to the application

--- a/main.go
+++ b/main.go
@@ -66,10 +66,18 @@ func runServer(c *cli.Context) error {
 		}
 		defer loader.Close()
 
+		// Truncate the database and start fresh
+		err = loader.Truncate()
+		if err != nil {
+			log.Fatal().Err(err).Send()
+		}
+
+		// Load the latest data
 		err = loader.Load()
 		if err != nil {
 			log.Fatal().Err(err).Send()
 		}
+
 		end := time.Now()
 		duration := end.Sub(start)
 		log.Info().Dur("load_time", duration).Msg("Background data load completed")

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,8 +1,21 @@
 ---
 applications:
-- name: FearlessDreamer2
-  docker:
-    image: nickrobisonusds/fearless-dreamer:latest
+- name: usds-covid-fearless-dreamer-backend
   disk_quota: 2G
+  memory: 128MB
+  timeout: 180
+  buildpacks:
+    - go_buildpack
   services:
-    - fearless-dreamer-psql
+    - usds-covid-fearless-dreamer-psql
+
+- name: usds-covid-fearless-dreamer
+  path: ui
+  memory: 512MB
+  buildpacks:
+    - nodejs_buildpack
+  env:
+    HOST: 127.0.0.1
+    REACT_APP_API_URI: "https://usds-covid-fearless-dreamer-backend.app.cloud.gov"
+    GENERATE_SOURCEMAP: false # Due to running out of memory
+    OPTIMIZE_MEMORY: true

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,21 +1,14 @@
 ---
 applications:
-- name: usds-covid-fearless-dreamer-backend
+- name: usds-covid-fearless-dreamer
   disk_quota: 2G
   memory: 128MB
   timeout: 180
   buildpacks:
     - go_buildpack
+    - nodejs_buildpack
   services:
     - usds-covid-fearless-dreamer-psql
-
-- name: usds-covid-fearless-dreamer
-  path: ui
-  memory: 512MB
-  buildpacks:
-    - nodejs_buildpack
   env:
-    HOST: 127.0.0.1
     REACT_APP_API_URI: "https://usds-covid-fearless-dreamer-backend.app.cloud.gov"
-    GENERATE_SOURCEMAP: false # Due to running out of memory
     OPTIMIZE_MEMORY: true

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,14 +1,29 @@
 ---
 applications:
 - name: usds-covid-fearless-dreamer
+
   disk_quota: 2G
   memory: 128MB
-  timeout: 180
+
+  # The go buildpack must be specified last for the go Procfile to be used
   buildpacks:
-    - go_buildpack
+    # The nodejs buildpack only run `yarn install` when specified as first buildpack
+    # To actually build the production resource `yarn build` has to be run somewhere in the process
+    # `yarn build` is currently being run locally with `yarn deploy` instead of building on server due to memory
+    # constraints. When run on the server, cloud.gov throws OOM errors, as the build process require >2GB of memory
+    # We need to optimize the memory during the build process, and then use the commented out command below
+    # When this occurs we can also add `ui/build` to .cfignore
     - nodejs_buildpack
+    - go_buildpack
+
   services:
     - usds-covid-fearless-dreamer-psql
+
+  # Use the default go start command by specifying null
+  command: null
+  #command: yarn build && ./bin/demand-modeling # Build react on the server
+  timeout: 180
+
   env:
     REACT_APP_API_URI: "https://usds-covid-fearless-dreamer-backend.app.cloud.gov"
     OPTIMIZE_MEMORY: true

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "install": "yarn --cwd ui/ install --production=false",
     "build.react": "yarn --cwd ui/ run build",
-    "build": "yarn run install && yarn run build.react"
+    "build": "yarn run install && yarn run build.react",
+    "cf.target": "cf target -o dhs-prototyping -s usds-covid",
+    "deploy": "yarn run cf.target && cf push"
   },
   "engines": {
     "yarn": "1.22.x"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build.react": "yarn --cwd ui/ run build",
     "build": "yarn run install && yarn run build.react",
     "cf.target": "cf target -o dhs-prototyping -s usds-covid",
-    "deploy": "yarn run cf.target && cf push"
+    "deploy": "yarn run build && yarn run cf.target && cf push"
   },
   "engines": {
     "yarn": "1.22.x"


### PR DESCRIPTION
### TLDR;

Deploy using `yarn run deploy`

### The Details

* Based this off `tim-best/daikon-loader`, so this PR is set to merge to that branch so we can see the changes in this branch only.
  * We can rebase and merge elsewhere, if desired.
* This branch also makes a change to load the data on a background thread, as cloud.gov has a max startup timeout of 120 seconds.
  * Several other commits do this as well, so we'll need to reconcile this somehow.
  * Leaving this here for now, but if we merge this into `tim-best/daikon-loader` we'll then need to reconcile there.
* The cloud.gov deploy is not building the react app.
  * This react build process runs out of memory during the build.
  * This seems to be related to https://github.com/facebook/create-react-app/issues/8096, but I wasn't able to get it to work using the mitigations they mention in the thread.
  * Our cloud.gov space is limited to 2GB across the whole account, so the recommendations increasing memory to 4GB were not feasible.
  * Instead, I opted to build the react app locally (compiling resources to `ui/build`) and then uploading it as part of deploy phase.
  * FYI: We still need to run `yarn install` as part of the build, as some CSS resources reference fonts and images stored in `node_modules`.
* As of right now, @timothybest-usds should also have access to the app in cloud.gov.
* The database is currently deployed as a free, shared tenancy service.
  * We can change the service type, if needed, to a paid database.