### PR TITLE
Fix sorting april 10

### DIFF
--- a/ui/src/components/USATotals.tsx
+++ b/ui/src/components/USATotals.tsx
@@ -12,9 +12,12 @@ const USATotal: React.FunctionComponent<Props> = props => {
     return Math.round((change / total) * 100);
   };
 
+  const defaultComparator = (a: any, b: any) => (a === b ? 0 : a < b ? -1 : 1);
+
+  // TODO: just make getCountyGrandTotal data be indexed by Date objects?
   const grandTotals: GrandTotal = getCountyGrandTotal(state);
   const dates = Object.keys(grandTotals)
-    .sort()
+    .sort((a: string, b: string) => defaultComparator(new Date(a), new Date(b)))
     .reverse();
 
   const total = grandTotals[dates[0]]?.Confirmed;

--- a/ui/src/components/USATotalsAlt.tsx
+++ b/ui/src/components/USATotalsAlt.tsx
@@ -6,7 +6,7 @@ import { getCountyGrandTotal, GrandTotal } from "../utils/calculations";
 interface Props {
   state?: string;
   county?: string;
-};
+}
 
 const USATotalsAlt: React.FunctionComponent<Props> = props => {
   const { state } = useContext(AppContext);
@@ -22,34 +22,43 @@ const USATotalsAlt: React.FunctionComponent<Props> = props => {
 
   const total = grandTotals[dates[0]]?.Confirmed;
 
-  const totalWithComma = (total).toLocaleString('en');
+  const totalWithComma = total.toLocaleString("en");
 
   const renderChange = (current: number, previous: number) => {
     if (current === undefined || previous === undefined) {
       return "N/A";
     }
     const change = current - previous;
-    return `${change >= 0 ? "+" : ""}${(change).toLocaleString('en')} (${percentChange(
-      current,
-      change
-    )} %)`;
+    return `${change >= 0 ? "+" : ""}${change.toLocaleString(
+      "en"
+    )} (${percentChange(current, change)} %)`;
   };
 
-const selectedState = state.selection.state === undefined ? 'National' : state.covidTimeSeries.states[state.selection.state][0].State;
+  const selectedState =
+    state.selection.state === undefined
+      ? "National"
+      : state.covidTimeSeries.states[state.selection.state][0].State;
 
-const selectedCounty = state.selection.county === undefined ? undefined : `: ` +  state.covidTimeSeries.counties[state.selection.county][0].County + ' County';
+  const selectedCounty =
+    state.selection.county === undefined
+      ? undefined
+      : `: ` +
+        state.covidTimeSeries.counties[state.selection.county][0].County +
+        " County";
 
   return (
     <div className="total-wrap">
-      <h1>{selectedState}{selectedCounty}</h1>
+      <h1>
+        {selectedState}
+        {selectedCounty}
+      </h1>
       <div className="total-item">
         <label className="usa-label">Confirmed cases</label>
         <span>{totalWithComma}</span>
       </div>
       <div className="total-item">
         <label className="usa-label">24-hour change</label>
-        <span>{renderChange(total, grandTotals[dates[1]]?.Confirmed)}
-        </span>
+        <span>{renderChange(total, grandTotals[dates[1]]?.Confirmed)}</span>
         {/* <Card header="48 hour Change">
           {renderChange(total, grandTotals[dates[2]].Confirmed)}
         </Card> */}

--- a/ui/src/components/USATotalsAlt.tsx
+++ b/ui/src/components/USATotalsAlt.tsx
@@ -15,9 +15,12 @@ const USATotalsAlt: React.FunctionComponent<Props> = props => {
     return Math.round((change / total) * 100);
   };
 
+  const defaultComparator = (a: any, b: any) => (a === b ? 0 : a < b ? -1 : 1);
+
+  // TODO: just make getCountyGrandTotal data be indexed by Date objects?
   const grandTotals: GrandTotal = getCountyGrandTotal(state);
   const dates = Object.keys(grandTotals)
-    .sort()
+    .sort((a: string, b: string) => defaultComparator(new Date(a), new Date(b)))
     .reverse();
 
   const total = grandTotals[dates[0]]?.Confirmed;

--- a/ui/src/utils/DateUtils.ts
+++ b/ui/src/utils/DateUtils.ts
@@ -55,9 +55,9 @@ export const dateTimeString = (date: Date) => {
 export const monthDay = (date: Date) => {
   const hour = addZero(date.getHours());
   const minute = addZero(date.getMinutes());
-  const m = date.getMonth()
+  const m = date.getMonth();
   const month = theMonths[m];
-  const day = date.getDate();
+  const day = addZero(date.getDate());
   const year = date.getFullYear();
   // Changing this may break all the bar graphs
   return `${year}${m}${day}${hour}:${minute}|${month}-${day}`;


### PR DESCRIPTION
Fix "April 10" < "April 6"

Time series data is often sorted by string representation, which is alphabetical, not numerical.  This screws up sorting by dates, unless they are padded with leading zeros.
